### PR TITLE
Compile fix for OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8)
 project(OculusSDK)
 
 add_subdirectory(LibOVR)
-add_subdirectory(Samples/OculusWorldDemo)
+#add_subdirectory(Samples/OculusWorldDemo)
 
 install(FILES package.xml DESTINATION share/oculus_sdk)
 

--- a/LibOVR/CMakeLists.txt
+++ b/LibOVR/CMakeLists.txt
@@ -26,15 +26,52 @@ set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH
 
 include_directories(Include)
 
+if(APPLE)
+  set(PLATFORM_SOURCE_FILES
+    Src/OVR_OSX_DeviceManager.cpp
+    Src/OVR_OSX_HIDDevice.cpp
+    Src/OVR_OSX_HMDDevice.cpp
+    Src/OVR_OSX_SensorDevice.cpp
+  )
+
+  set(PLATFORM_HEADER_FILES
+    Src/OVR_OSX_HIDDevice.h
+    Src/OVR_OSX_DeviceManager.h
+    Src/OVR_OSX_HMDDevice.h
+  )
+
+  find_library(COCOA_LIBRARY Cocoa)
+  find_library(IOKIT_LIBRARY IOKit)
+  set(EXTRA_LIBS ${COCOA_LIBRARY} ${IOKIT_LIBRARY})
+
+elseif(UNIX)
+  set(PLATFORM_SOURCE_FILES
+    Src/OVR_Linux_DeviceManager.cpp
+    Src/OVR_Linux_HIDDevice.cpp
+    Src/OVR_Linux_HMDDevice.cpp
+    Src/OVR_Linux_SensorDevice.cpp
+  )
+
+  set(PLATFORM_HEADER_FILES
+    Src/OVR_Linux_HIDDevice.h
+    Src/OVR_Linux_DeviceManager.h
+    Src/OVR_Linux_HMDDevice.h
+  )
+
+  set(EXTRA_LIBS
+    udev
+    pthread
+    GL
+    X11
+    Xinerama
+  )
+endif()
+
 set(SOURCE_FILES
   Src/OVR_DeviceHandle.cpp
   Src/OVR_DeviceImpl.cpp
   Src/OVR_JSON.cpp
   Src/OVR_LatencyTestImpl.cpp
-  Src/OVR_Linux_DeviceManager.cpp
-  Src/OVR_Linux_HIDDevice.cpp
-  Src/OVR_Linux_HMDDevice.cpp
-  Src/OVR_Linux_SensorDevice.cpp
   Src/OVR_Profile.cpp
   Src/OVR_SensorFilter.cpp
   Src/OVR_SensorFusion.cpp
@@ -60,12 +97,12 @@ set(SOURCE_FILES
   Src/Kernel/OVR_ThreadsPthread.cpp
   Src/Kernel/OVR_Timer.cpp
   Src/Kernel/OVR_UTF8Util.cpp
-  
-  )
+  ${PLATFORM_SOURCE_FILES}
+)
 
 add_library(ovr SHARED ${SOURCE_FILES})
 
-target_link_libraries(ovr udev pthread GL X11 Xinerama)
+target_link_libraries(ovr ${EXTRA_LIBS})
 
 set(INCLUDE_HEADER_FILES
   Include/OVR.h
@@ -73,8 +110,6 @@ set(INCLUDE_HEADER_FILES
 )
 
 set(SRC_HEADER_FILES
-  Src/OVR_Linux_HIDDevice.h
-  Src/OVR_Linux_DeviceManager.h
   Src/OVR_SensorFilter.h
   Src/OVR_Win32_DeviceManager.h
   Src/OVR_Win32_HIDDevice.h
@@ -86,7 +121,6 @@ set(SRC_HEADER_FILES
   Src/OVR_OSX_DeviceManager.h
   Src/OVR_DeviceHandle.h
   Src/OVR_HIDDevice.h
-  Src/OVR_Linux_HMDDevice.h
   Src/OVR_Win32_DeviceStatus.h
   Src/OVR_HIDDeviceBase.h
   Src/OVR_JSON.h
@@ -99,6 +133,7 @@ set(SRC_HEADER_FILES
   Src/OVR_LatencyTestImpl.h
   Src/OVR_SensorImpl.h
   Src/OVR_DeviceMessages.h
+  ${PLATFORM_HEADER_FILES}
 )
 set(KERNEL_HEADER_FILES
   Src/Kernel/OVR_Threads.h
@@ -155,16 +190,18 @@ INSTALL(TARGETS ovr
   ARCHIVE DESTINATION ${INSTALL_LIB_DIR}
 )
 
-option(INSTALL_UDEV_RULES "Install udev rules for Oculus Rift" ON)
-IF (INSTALL_UDEV_RULES)
-  INSTALL (
-    FILES 90-oculus-hydro.rules
-    DESTINATION "/etc/udev/rules.d"
-    COMPONENT "udev"
-    )
-else (INSTALL_UDEV_RULES)
-  message (STATUS "Udev rules not being installed, install them with -DINSTALL_UDEV_RULES=ON")
-endif (INSTALL_UDEV_RULES)
+if (NOT APPLE)
+  option(INSTALL_UDEV_RULES "Install udev rules for Oculus Rift" ON)
+  IF (INSTALL_UDEV_RULES)
+    INSTALL (
+      FILES 90-oculus-hydro.rules
+      DESTINATION "/etc/udev/rules.d"
+      COMPONENT "udev"
+      )
+  else (INSTALL_UDEV_RULES)
+    message (STATUS "Udev rules not being installed, install them with -DINSTALL_UDEV_RULES=ON")
+  endif (INSTALL_UDEV_RULES)
+endif()
 
 
 

--- a/LibOVR/Src/OVR_OSX_HMDDevice.h
+++ b/LibOVR/Src/OVR_OSX_HMDDevice.h
@@ -17,7 +17,7 @@ otherwise accompanies this software in either electronic or hard copy form.
 #define OVR_OSX_HMDDevice_h
 
 #include "OVR_DeviceImpl.h"
-#include <Kernel/OVR_String.h>
+#include "Kernel/OVR_String.h"
 #include "OVR_Profile.h"
 
 namespace OVR { namespace OSX {

--- a/Samples/OculusWorldDemo/CMakeLists.txt
+++ b/Samples/OculusWorldDemo/CMakeLists.txt
@@ -29,7 +29,7 @@ SET(SOURCE_FILES
   ../../Samples/CommonSrc/Render/Render_LoadTextureDDS.cpp
   ../../Samples/CommonSrc/Render/Render_LoadTextureTGA.cpp
   ../../Samples/CommonSrc/Render/Render_XmlSceneLoader.cpp
-  ${PLATFORM_FILES}
+  ${PLATFORM_SOURCE_FILES}
   )
 
 

--- a/Samples/OculusWorldDemo/CMakeLists.txt
+++ b/Samples/OculusWorldDemo/CMakeLists.txt
@@ -4,28 +4,45 @@ INCLUDE_DIRECTORIES(../../LibOVR/Include ../../LibOVR/Src)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_WEBKIT -DGL_GLEXT_PROTOTYPES")
 
+if (APPLE)
+  set(PLATFORM_SOURCE_FILES
+    ../../Samples/CommonSrc/Platform/OSX_Platform.mm
+    ../../Samples/CommonSrc/Platform/OSX_Gamepad.cpp
+  )
+
+  find_library(OPENGL_LIBRARY OpenGL)
+  set(EXTRA_LIBS ovr tinyxml2_embedded ${OPENGL_LIBRARY})
+elseif (UNIX)
+  set(PLATFORM_SOURCE_FILES
+    ../../Samples/CommonSrc/Platform/Linux_Platform.cpp
+    ../../Samples/CommonSrc/Platform/Linux_Gamepad.cpp
+  )
+
+  set(EXTRA_LIBS ovr tinyxml2_embedded udev pthread GL X11 Xinerama)
+endif()
+
 SET(SOURCE_FILES
   Player.cpp
   ../../Samples/CommonSrc/Platform/Platform.cpp
-  ../../Samples/CommonSrc/Platform/Linux_Platform.cpp
-  ../../Samples/CommonSrc/Platform/Linux_Gamepad.cpp
   ../../Samples/CommonSrc/Render/Render_Device.cpp
   ../../Samples/CommonSrc/Render/Render_GL_Device.cpp
   ../../Samples/CommonSrc/Render/Render_LoadTextureDDS.cpp
   ../../Samples/CommonSrc/Render/Render_LoadTextureTGA.cpp
   ../../Samples/CommonSrc/Render/Render_XmlSceneLoader.cpp
+  ${PLATFORM_FILES}
   )
 
 
 add_library(OculusWorld SHARED
   ${SOURCE_FILES}
   )
+target_link_libraries(OculusWorld ${EXTRA_LIBS})
 
 
 add_library(tinyxml2_embedded ../../3rdParty/TinyXml/tinyxml2.cpp)
 
 add_executable(OculusWorldDemo OculusWorldDemo.cpp)
-target_link_libraries(OculusWorldDemo OculusWorld ovr tinyxml2_embedded udev pthread GL X11 Xinerama)
+target_link_libraries(OculusWorldDemo OculusWorld ${EXTRA_LIBS})
 
 
 


### PR DESCRIPTION
This adds a number of checks to make the SDK compile under OSX.

ps. I didn't bother with the world demo. Should it not perhaps just be deleted?
